### PR TITLE
Don't use enum's in the schema arrays

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -73,3 +73,74 @@ where the value of profile matches the resolution scope of the NodeInfo
 schema version that's being returned.
 
 A sever may provide additional representations.
+
+## Data contents
+
+Known data element values. Using these will ensure interoperatibility between other nodes using NodeInfo. Please provide additional items that are common in your implementation to these lists via PR's.
+
+### `software.name`
+
+* `diaspora`
+* `friendica`
+* `hubzilla`
+
+### `protocols.inbound.items`
+
+* `buddycloud`
+* `diaspora`
+* `friendica`
+* `gnusocial`
+* `libertree`
+* `mediagoblin`
+* `pumpio`
+* `redmatrix`
+* `smtp`
+* `tent`
+
+### `protocols.outbound.items`
+
+* `buddycloud`
+* `diaspora`
+* `friendica`
+* `gnusocial`
+* `libertree`
+* `mediagoblin`
+* `pumpio`
+* `redmatrix`
+* `smtp`
+* `tent`
+
+### `services.inbound.items`
+
+* `appnet`
+* `gnusocial`
+* `pumpio`
+
+### `services.outbound.items`
+
+* `appnet`
+* `blogger`
+* `buddycloud`
+* `diaspora`
+* `dreamwidth`
+* `drupal`
+* `facebook`
+* `friendica`
+* `gnusocial`
+* `google`
+* `insanejournal`
+* `libertree`
+* `linkedin`
+* `livejournal`
+* `mediagoblin`
+* `myspace`
+* `pinterest`
+* `posterous`
+* `pumpio`
+* `redmatrix`
+* `smtp`
+* `tent`
+* `tumblr`
+* `twitter`
+* `wordpress`
+* `xmpp`

--- a/schemas/1.0/schema.json
+++ b/schemas/1.0/schema.json
@@ -31,11 +31,7 @@
       "properties": {
         "name": {
           "description": "The canonical name of this server software.",
-          "enum": [
-            "diaspora",
-            "friendica",
-            "redmatrix"
-          ]
+          "type": "string"
         },
         "version": {
           "description": "The version of this server software.",
@@ -57,18 +53,7 @@
           "type": "array",
           "minItems": 1,
           "items": {
-            "enum": [
-              "buddycloud",
-              "diaspora",
-              "friendica",
-              "gnusocial",
-              "libertree",
-              "mediagoblin",
-              "pumpio",
-              "redmatrix",
-              "smtp",
-              "tent"
-            ]
+            "type": "string"
           }
         },
         "outbound": {
@@ -76,18 +61,7 @@
           "type": "array",
           "minItems": 1,
           "items": {
-            "enum": [
-              "buddycloud",
-              "diaspora",
-              "friendica",
-              "gnusocial",
-              "libertree",
-              "mediagoblin",
-              "pumpio",
-              "redmatrix",
-              "smtp",
-              "tent"
-            ]
+            "type": "string"
           }
         }
       }
@@ -106,11 +80,7 @@
           "type": "array",
           "minItems": 0,
           "items": {
-            "enum": [
-              "appnet",
-              "gnusocial",
-              "pumpio"
-            ]
+            "type": "string"
           }
         },
         "outbound": {
@@ -118,34 +88,7 @@
           "type": "array",
           "minItems": 0,
           "items": {
-            "enum": [
-              "appnet",
-              "blogger",
-              "buddycloud",
-              "diaspora",
-              "dreamwidth",
-              "drupal",
-              "facebook",
-              "friendica",
-              "gnusocial",
-              "google",
-              "insanejournal",
-              "libertree",
-              "linkedin",
-              "livejournal",
-              "mediagoblin",
-              "myspace",
-              "pinterest",
-              "posterous",
-              "pumpio",
-              "redmatrix",
-              "smtp",
-              "tent",
-              "tumblr",
-              "twitter",
-              "wordpress",
-              "xmpp"
-            ]
+            "type": "string"
           }
         }
       }


### PR DESCRIPTION
Don't lock array values in the schema document via enums. This will make NodeInfo much more usable without requiring a new version be published each time a new server implementation, protocol or service is required to be represented.

IMHO this is the biggest problem for using NodeInfo in a more larger audience. Requiring a new version just to represent a new type of server is basically making it unusable. For example, I want to use NodeInfo to expose the relay servers. Instead of requesting this to be approved by the person owning NodeInfo, I should be able to just do it using my own key. Other implementors can choose to recognize this key if they want, but the schema shouldn't stop me representing my server with NodeInfo.

For the services this is an even bigger problem. Look at half of the NodeInfo generated by Friendica servers - due to the limitations of NodeInfo, they put a second copy of the services list in the extra free data, making the whole point of having an array of services pointless.

Could we consider this change before 1.0 is locked? Current status is subject to change.
