### PR TITLE
Don't use enum's in the schema arrays

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -73,3 +73,74 @@ where the value of profile matches the resolution scope of the NodeInfo
 schema version that's being returned.
 
 A sever may provide additional representations.
+
+## Data contents
+
+Known data element values. Using these will ensure interoperatibility between other nodes using NodeInfo. Please provide additional items that are common in your implementation to these lists via PR's.
+
+### `software.name`
+
+* `diaspora`
+* `friendica`
+* `hubzilla`
+
+### `protocols.inbound.items`
+
+* `buddycloud`
+* `diaspora`
+* `friendica`
+* `gnusocial`
+* `libertree`
+* `mediagoblin`
+* `pumpio`
+* `redmatrix`
+* `smtp`
+* `tent`
+
+### `protocols.outbound.items`
+
+* `buddycloud`
+* `diaspora`
+* `friendica`
+* `gnusocial`
+* `libertree`
+* `mediagoblin`
+* `pumpio`
+* `redmatrix`
+* `smtp`
+* `tent`
+
+### `services.inbound.items`
+
+* `appnet`
+* `gnusocial`
+* `pumpio`
+
+### `services.outbound.items`
+
+* `appnet`
+* `blogger`
+* `buddycloud`
+* `diaspora`
+* `dreamwidth`
+* `drupal`
+* `facebook`
+* `friendica`
+* `gnusocial`
+* `google`
+* `insanejournal`
+* `libertree`
+* `linkedin`
+* `livejournal`
+* `mediagoblin`
+* `myspace`
+* `pinterest`
+* `posterous`
+* `pumpio`
+* `redmatrix`
+* `smtp`
+* `tent`
+* `tumblr`
+* `twitter`
+* `wordpress`
+* `xmpp`

--- a/schemas/1.0/schema.json
+++ b/schemas/1.0/schema.json
@@ -31,11 +31,7 @@
       "properties": {
         "name": {
           "description": "The canonical name of this server software.",
-          "enum": [
-            "diaspora",
-            "friendica",
-            "redmatrix"
-          ]
+          "type": "string"
         },
         "version": {
           "description": "The version of this server software.",
@@ -57,18 +53,7 @@
           "type": "array",
           "minItems": 1,
           "items": {
-            "enum": [
-              "buddycloud",
-              "diaspora",
-              "friendica",
-              "gnusocial",
-              "libertree",
-              "mediagoblin",
-              "pumpio",
-              "redmatrix",
-              "smtp",
-              "tent"
-            ]
+            "type": "string"
           }
         },
         "outbound": {
@@ -76,18 +61,7 @@
           "type": "array",
           "minItems": 1,
           "items": {
-            "enum": [
-              "buddycloud",
-              "diaspora",
-              "friendica",
-              "gnusocial",
-              "libertree",
-              "mediagoblin",
-              "pumpio",
-              "redmatrix",
-              "smtp",
-              "tent"
-            ]
+            "type": "string"
           }
         }
       }
@@ -106,11 +80,7 @@
           "type": "array",
           "minItems": 0,
           "items": {
-            "enum": [
-              "appnet",
-              "gnusocial",
-              "pumpio"
-            ]
+            "type": "string"
           }
         },
         "outbound": {
@@ -118,34 +88,7 @@
           "type": "array",
           "minItems": 0,
           "items": {
-            "enum": [
-              "appnet",
-              "blogger",
-              "buddycloud",
-              "diaspora",
-              "dreamwidth",
-              "drupal",
-              "facebook",
-              "friendica",
-              "gnusocial",
-              "google",
-              "insanejournal",
-              "libertree",
-              "linkedin",
-              "livejournal",
-              "mediagoblin",
-              "myspace",
-              "pinterest",
-              "posterous",
-              "pumpio",
-              "redmatrix",
-              "smtp",
-              "tent",
-              "tumblr",
-              "twitter",
-              "wordpress",
-              "xmpp"
-            ]
+            "type": "string"
           }
         }
       }


### PR DESCRIPTION
Don't lock array values in the schema document via enums. This will make NodeInfo much more usable without requiring a new version be published each time a new server implementation, protocol or service is required to be represented.

Upstream patch was rejected, thus maintaining in own fork.
